### PR TITLE
refactor: version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Get a pair of emitter and receiver.
 
 ##### Synopsys
 ```ts
-function useEvents<T extends EventMap>(): [IEmitter<T>, IReceiver<T>]
+function useEvents<T extends TEventMap>(): [TEmitter<T>, IReceiver<T>]
 ```
 
 ##### Example
@@ -24,16 +24,16 @@ interface MyEvents {
     "event1": number
     "event2": string
 }
-const [emitter, receiver] = useEvent<MyEvents>()
+const [emit, receiver] = useEvent<MyEvents>()
 
 receiver.on("event1", data => { /* ... */ })   // called every time event1 is emitted
 receiver.once("event2", data => { /* ... */ }) // called once
 
-emitter.emit("event1", 42)
-emitter.emit("event2", "foo")
+emit("event1", 42)
+emit("event2", "foo")
 ```
 
-### EventMap
+### TEventMap
 An `EventMap` type is used to type subscriptions to events as well as their
 emissions.
 
@@ -45,7 +45,7 @@ type MyEvents = {
         y: number
     }
 }
-const [emitter, receiver] = useEvent<MyEvents>()
+const [emit, receiver] = useEvent<MyEvents>()
 
 receiver.on("event1", data => {
     console.log(data.toUpperCase())
@@ -55,9 +55,9 @@ receiver.once("event2", data => {
     console.log(data.z)
 }) // Error: Property 'z' does not exist on type '{ x: number; y: number; }'.
 
-emitter.emit(event1, "test") // Ok
+emit(event1, "test") // Ok
 
-emitter.emit(event2, {
+emit(event2, {
     x: 1,
     z: 2,
 }) // Error: Argument of type '{ w: number; y: number; }' is not assignable to parameter of type '{ x: number; y: number; }'
@@ -65,18 +65,16 @@ emitter.emit(event2, {
 
 If no `EventMap` type is specified, there will be no type checking.
 ```ts
-const [emitter, receiver] = useEvent()
+const [emit, receiver] = useEvent()
 
 receiver.on("event1", data => { ... })   // data type is any
 receiver.once("event2", data => { ... }) // data type is any
 
-emitter.emit(event1, { r: 0xb4, g: 0xd4, b: 0x55 })
-emitter.emit(event2, 3.14)
+emit(event1, { r: 0xb4, g: 0xd4, b: 0x55 })
+emit(event2, 3.14)
 ```
 
-### IEmitter
-
-#### emit
+### TEmitter
 
 ##### Synopsis
 ```ts
@@ -85,11 +83,11 @@ function emit(event, data)
 
 ##### Example
 ```ts
-const [emitter, receiver] = useEvent<{
+const [emit, receiver] = useEvent<{
     event1: number
 }>()
 
-emitter.emit("event1", 3.14)
+emit("event1", 3.14)
 ```
 
 ### IReceiver

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nealrame/ts-events",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A simple Emitter/Receiver library for Typescript",
   "main": "./dist/index.js",
   "files": [

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,15 +2,15 @@ export type TEventListenerCallback<EventType> = (event: EventType) => void
 export type TEventListenerUnsubscribeCallback = () => void
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type EventMap = Record<string, any>
-export type EventKey<T extends EventMap> = string & keyof T
+export type TEventMap = Record<string, any>
+export type EventKey<T extends TEventMap> = string & keyof T
 
-export interface IEmitter<T extends EventMap> {
+export interface IEmitter<T extends TEventMap> {
     emit<K extends EventKey<T>>(eventName: K, ...[eventData]: void extends T[K] ? [void] : [T[K]]): IEmitter<T>
     emit<K extends EventKey<T>>(eventName: K, eventData: T[K]): IEmitter<T>
 }
 
-export interface IReceiver<T extends EventMap> {
+export interface IReceiver<T extends TEventMap> {
     on<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
     once<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
 
@@ -19,7 +19,7 @@ export interface IReceiver<T extends EventMap> {
     off<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): void
 }
 
-export function useEvents<T extends EventMap>()
+export function useEvents<T extends TEventMap>()
     : [IEmitter<T>, IReceiver<T>] {
     let handlers: { [K in keyof T]?: Array<TEventListenerCallback<T[K]>> } = {}
     let handlersOnce: { [K in keyof T]?: Array<TEventListenerCallback<T[K]>> } = {}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,20 +3,20 @@ export type TEventListenerUnsubscribeCallback = () => void
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type TEventMap = Record<string, any>
-export type EventKey<T extends TEventMap> = string & keyof T
+export type TEventKey<T extends TEventMap> = string & keyof T
 
 export interface IEmitter<T extends TEventMap> {
-    emit<K extends EventKey<T>>(eventName: K, ...[eventData]: void extends T[K] ? [void] : [T[K]]): IEmitter<T>
-    emit<K extends EventKey<T>>(eventName: K, eventData: T[K]): IEmitter<T>
+    emit<K extends TEventKey<T>>(eventName: K, ...[eventData]: void extends T[K] ? [void] : [T[K]]): IEmitter<T>
+    emit<K extends TEventKey<T>>(eventName: K, eventData: T[K]): IEmitter<T>
 }
 
 export interface IReceiver<T extends TEventMap> {
-    on<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
-    once<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
+    on<K extends TEventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
+    once<K extends TEventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
 
     off(): void
-    off<K extends EventKey<T>>(eventName: K): void
-    off<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): void
+    off<K extends TEventKey<T>>(eventName: K): void
+    off<K extends TEventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): void
 }
 
 export function useEvents<T extends TEventMap>()
@@ -25,7 +25,7 @@ export function useEvents<T extends TEventMap>()
     let handlersOnce: { [K in keyof T]?: Array<TEventListenerCallback<T[K]>> } = {}
 
     return [{
-        emit<K extends EventKey<T>>(
+        emit<K extends TEventKey<T>>(
             eventName: K,
             data: T[K]
         ): IEmitter<T> {
@@ -43,7 +43,7 @@ export function useEvents<T extends TEventMap>()
             return this
         }
     }, {
-        on<K extends EventKey<T>>(
+        on<K extends TEventKey<T>>(
             eventName: K,
             callback: TEventListenerCallback<T[K]>,
         ): TEventListenerUnsubscribeCallback {
@@ -56,7 +56,7 @@ export function useEvents<T extends TEventMap>()
 
             return () => this.off(eventName, callback)
         },
-        once<K extends EventKey<T>>(
+        once<K extends TEventKey<T>>(
             eventName: K,
             callback: TEventListenerCallback<T[K]>,
         ): TEventListenerUnsubscribeCallback {
@@ -69,7 +69,7 @@ export function useEvents<T extends TEventMap>()
 
             return () => this.off(eventName, callback)
         },
-        off<K extends EventKey<T>>(
+        off<K extends TEventKey<T>>(
             eventName?: K,
             callback?: TEventListenerCallback<T[K]>,
         ) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,5 @@
 export type TEventListenerCallback<EventType> = (event: EventType) => void
-export type EventListenerUnsubscribeCallback = () => void
+export type TEventListenerUnsubscribeCallback = () => void
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EventMap = Record<string, any>
@@ -11,8 +11,8 @@ export interface IEmitter<T extends EventMap> {
 }
 
 export interface IReceiver<T extends EventMap> {
-    on<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): EventListenerUnsubscribeCallback
-    once<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): EventListenerUnsubscribeCallback
+    on<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
+    once<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): TEventListenerUnsubscribeCallback
 
     off(): void
     off<K extends EventKey<T>>(eventName: K): void
@@ -46,7 +46,7 @@ export function useEvents<T extends EventMap>()
         on<K extends EventKey<T>>(
             eventName: K,
             callback: TEventListenerCallback<T[K]>,
-        ): EventListenerUnsubscribeCallback {
+        ): TEventListenerUnsubscribeCallback {
             type ListenerList = Array<TEventListenerCallback<T[K]>>
 
             if (!(eventName in handlers)) {
@@ -59,7 +59,7 @@ export function useEvents<T extends EventMap>()
         once<K extends EventKey<T>>(
             eventName: K,
             callback: TEventListenerCallback<T[K]>,
-        ): EventListenerUnsubscribeCallback {
+        ): TEventListenerUnsubscribeCallback {
             type ListenerList = Array<TEventListenerCallback<T[K]>>
 
             if (!(eventName in handlersOnce)) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,4 @@
-export type EventListenerCallback<EventType> = (event: EventType) => void
+export type TEventListenerCallback<EventType> = (event: EventType) => void
 export type EventListenerUnsubscribeCallback = () => void
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,18 +11,18 @@ export interface IEmitter<T extends EventMap> {
 }
 
 export interface IReceiver<T extends EventMap> {
-    on<K extends EventKey<T>>(eventName: K, callback: EventListenerCallback<T[K]>): EventListenerUnsubscribeCallback
-    once<K extends EventKey<T>>(eventName: K, callback: EventListenerCallback<T[K]>): EventListenerUnsubscribeCallback
+    on<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): EventListenerUnsubscribeCallback
+    once<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): EventListenerUnsubscribeCallback
 
     off(): void
     off<K extends EventKey<T>>(eventName: K): void
-    off<K extends EventKey<T>>(eventName: K, callback: EventListenerCallback<T[K]>): void
+    off<K extends EventKey<T>>(eventName: K, callback: TEventListenerCallback<T[K]>): void
 }
 
 export function useEvents<T extends EventMap>()
     : [IEmitter<T>, IReceiver<T>] {
-    let handlers: { [K in keyof T]?: Array<EventListenerCallback<T[K]>> } = {}
-    let handlersOnce: { [K in keyof T]?: Array<EventListenerCallback<T[K]>> } = {}
+    let handlers: { [K in keyof T]?: Array<TEventListenerCallback<T[K]>> } = {}
+    let handlersOnce: { [K in keyof T]?: Array<TEventListenerCallback<T[K]>> } = {}
 
     return [{
         emit<K extends EventKey<T>>(
@@ -45,9 +45,9 @@ export function useEvents<T extends EventMap>()
     }, {
         on<K extends EventKey<T>>(
             eventName: K,
-            callback: EventListenerCallback<T[K]>,
+            callback: TEventListenerCallback<T[K]>,
         ): EventListenerUnsubscribeCallback {
-            type ListenerList = Array<EventListenerCallback<T[K]>>
+            type ListenerList = Array<TEventListenerCallback<T[K]>>
 
             if (!(eventName in handlers)) {
                 handlers[eventName] = []
@@ -58,9 +58,9 @@ export function useEvents<T extends EventMap>()
         },
         once<K extends EventKey<T>>(
             eventName: K,
-            callback: EventListenerCallback<T[K]>,
+            callback: TEventListenerCallback<T[K]>,
         ): EventListenerUnsubscribeCallback {
-            type ListenerList = Array<EventListenerCallback<T[K]>>
+            type ListenerList = Array<TEventListenerCallback<T[K]>>
 
             if (!(eventName in handlersOnce)) {
                 handlersOnce[eventName] = []
@@ -71,7 +71,7 @@ export function useEvents<T extends EventMap>()
         },
         off<K extends EventKey<T>>(
             eventName?: K,
-            callback?: EventListenerCallback<T[K]>,
+            callback?: TEventListenerCallback<T[K]>,
         ) {
             if (eventName == null) {
                 handlers = {}

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -25,29 +25,24 @@ describe("useEvents", () => {
     })
 
     it("should return a pair of emitter and receiver", () => {
-        const [emitter, receiver] = useEvents()
-        expect(emitter).to.be.an("object")
+        const [emit, receiver] = useEvents()
+        expect(emit).to.be.a("function")
         expect(receiver).to.be.an("object")
     })
 })
 
 describe("IEmitter", () => {
     it("should have a method emit", () => {
-        const [emitter] = useEvents()
-        expect(emitter.emit).to.be.a("function")
-    })
-
-    it("should return itself when emit", () => {
-        const [emitter] = useEvents()
-        expect(emitter.emit("test", "test")).to.equal(emitter)
+        const [emit] = useEvents()
+        expect(emit).to.be.a("function")
     })
 
     it("should accept void event type", () => {
-        const [emitter] = useEvents<{
+        const [emit] = useEvents<{
             test: void
         }>()
-        expect(emitter.emit("test")).to.equal(emitter)
-        expect(emitter.emit("test", undefined)).to.equal(emitter)
+        expect(emit("test")).to.be.undefined
+        expect(emit("test", undefined)).to.be.undefined
     })
 })
 
@@ -59,28 +54,28 @@ describe("IReceiver", () => {
         })
 
         it("should call the event callback with the event data", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback = fake()
             receiver.on("test", callback)
-            emitter.emit("test", "test")
+            emit("test", "test")
             expect(callback).to.have.been.calledWith("test")
         })
 
         it("should call the event callback each time the event is emitted", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback = fake()
             receiver.on("test", callback)
-            emitter.emit("test", "test")
-            emitter.emit("test", "test")
+            emit("test", "test")
+            emit("test", "test")
             expect(callback).to.have.been.calledTwice
         })
 
         it("shoud unsubscribe the event when the returned function is called", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback = fake()
             const unsubscribe = receiver.on("test", callback)
             unsubscribe()
-            emitter.emit("test", "test")
+            emit("test", "test")
             expect(callback).to.not.have.been.called
         })
     })
@@ -92,66 +87,66 @@ describe("IReceiver", () => {
         })
 
         it("should call the event callback with the event data", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback = fake()
             receiver.once("test", callback)
-            emitter.emit("test", "test")
+            emit("test", "test")
             expect(callback).to.have.been.calledWith("test")
         })
 
         it("should call the event callback only once", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback = fake()
             receiver.once("test", callback)
-            emitter.emit("test", "test")
-            emitter.emit("test", "test")
+            emit("test", "test")
+            emit("test", "test")
             expect(callback).to.have.been.calledOnce
         })
 
         it("shoud unsubscribe the event when the returned function is called", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback = fake()
             const unsubscribe = receiver.once("test", callback)
             unsubscribe()
-            emitter.emit("test", "test")
+            emit("test", "test")
             expect(callback).to.not.have.been.called
         })
     })
 
     describe("#off", () => {
         it("should unsubscribe a given listener to the event", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback1 = fake()
             const callback2 = fake()
             receiver.on("test", callback1)
             receiver.on("test", callback2)
             receiver.off("test", callback1)
-            emitter.emit("test", "test")
+            emit("test", "test")
             expect(callback1).to.not.have.been.called
             expect(callback2).to.have.been.called
         })
 
         it("should unsubscribe all listeners to the event if no listener is given", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback1 = fake()
             const callback2 = fake()
             receiver.on("test", callback1)
             receiver.on("test", callback2)
             receiver.off("test")
-            emitter.emit("test", "test")
+            emit("test", "test")
             expect(callback1).to.not.have.been.called
             expect(callback2).to.not.have.been.called
         })
 
         it("should unsubscribe all listeners to all events if no event is given", () => {
-            const [emitter, receiver] = useEvents()
+            const [emit, receiver] = useEvents()
             const callback1 = fake()
             const callback2 = fake()
             receiver.on("test1", callback1)
             receiver.on("test2", callback2)
             receiver.off()
-            emitter.emit("test1", "test")
-            emitter.emit("test2", "test")
+            emit("test1", "test")
+            emit("test2", "test")
             expect(callback1).to.not.have.been.called
             expect(callback2).to.not.have.been.called
         })


### PR DESCRIPTION
1. Rename types to support the following convention:
  * _type_ name begins with a capital _T_,
  * _interface_ name begins with a capital _I_.
2. _Emitter_ is now a simple function to avoid `emitter.emit(...)`.

